### PR TITLE
feat(python): use returncode for python exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,13 @@ grep extra_css README.md && exit 2
 ```
 ````
 
+You can also expect a type of Exception in Python:
+
+````md
+```python exec="1" source="tabbed-left" exception="ValueError"
+raise ValueError
+```
+````
+
 See [usage](https://pawamoy.github.io/markdown-exec/usage/) for more details,
 and the [gallery](https://pawamoy.github.io/markdown-exec/gallery/) for more examples!

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -33,6 +33,7 @@ linking to their related documentation:
 - [`idprefix`](#html-ids): Change or remove the prefix in front of HTML ids/hrefs.
 - [`result`](#wrap-result-in-a-code-block): Choose the syntax highlight of your code block output.
 - [`returncode`](shell.md#expecting-a-non-zero-exit-code): Tell what return code is expected (shell code).
+- [`exception`](python.md#expecting-an-exception): Tell what exception code is expected (python code).
 - [`session`](#sessions): Execute code blocks within a named session, reusing previously defined variables, etc..
 - [`source`](#render-the-source-code-as-well): Render the source as well as the output.
 - [`tabs`](#change-the-titles-of-tabs): When rendering the source using tabs, choose the tabs titles.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -336,8 +336,11 @@ Example:
 Code blocks execution can fail.
 For example, your Python code may raise exceptions,
 or your shell code may return a non-zero exit code
-(for shell commands that are expected to return non-zero,
-see [Expecting a non-zero exit code](shell.md#expecting-a-non-zero-exit-code)).
+For shell commands that are expected to return non-zero,
+see [Expecting a non-zero exit code](shell.md#expecting-a-non-zero-exit-code).
+
+For python blocks that are expected to raise an exception
+see [Expecting an Exception](python.md#expecting-an-exception).
 
 In these cases, the exception and traceback (Python),
 or the current output (shell) will be rendered

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -37,3 +37,30 @@ as well as their output:
 --8<-- "usage/multiple.pycon"
 ```
 ````
+
+## Expecting an `Exception`
+
+You will sometimes want to run Python code that you
+expect to raise an `Exception`. 
+For example to show how errors look to your users.
+
+You can tell Markdown Exec to expect
+a particular `Exception` code with the `exception` option:
+
+````md
+```python exec="true" exception="ValueError"
+print("This will run")
+raise ValueError("This is a value error")
+print("This will not run")
+```
+````
+
+In that case, the executed code won't be considered
+to have failed, its output will be rendered normally,
+and no warning will be logged in the MkDocs output,
+allowing your strict builds to pass.
+
+If the `exception` code is different than the one specified
+with `exception=`, it will be considered a failure,
+only the traceback will be renderer
+and a warning will be logged in the MkDocs output.

--- a/src/markdown_exec/__init__.py
+++ b/src/markdown_exec/__init__.py
@@ -74,6 +74,7 @@ def validator(
     source_value = inputs.pop("source", "")
     result_value = inputs.pop("result", "")
     returncode_value = int(inputs.pop("returncode", "0"))
+    exception_value = inputs.pop("exception", None)
     session_value = inputs.pop("session", "")
     update_toc_value = _to_bool(inputs.pop("updatetoc", "yes"))
     tabs_value = inputs.pop("tabs", "|".join(default_tabs))
@@ -86,6 +87,7 @@ def validator(
     options["source"] = source_value
     options["result"] = result_value
     options["returncode"] = returncode_value
+    options["exception"] = exception_value
     options["session"] = session_value
     options["update_toc"] = update_toc_value
     options["tabs"] = tabs

--- a/src/markdown_exec/formatters/base.py
+++ b/src/markdown_exec/formatters/base.py
@@ -119,8 +119,8 @@ def base_format(
         tabs: Titles of tabs (if used).
         id: An optional ID for the code block (useful when warning about errors).
         id_prefix: A string used to prefix HTML ids in the generated HTML.
-        returncode: The expected exit code.
-        exception: The expected Exception raised. Python only 
+        returncode: The expected exit code. shell only
+        exception: The expected Exception raised. python or pycon only
         transform_source: An optional callable that returns transformed versions of the source.
             The input source is the one that is ran, the output source is the one that is
             rendered (when the source option is enabled).

--- a/src/markdown_exec/formatters/base.py
+++ b/src/markdown_exec/formatters/base.py
@@ -154,7 +154,9 @@ def base_format(
         if error.returncode is not None:
             exit_message = f"returncode {error.returncode} expected {returncode}"
         elif error.exception is not None:
-            exit_message = f"{error.exception} expected {exception} "
+            exit_message = f"{error.exception}"
+            if exception is not None:
+                exit_message += f" expected {exception}"
         else:
             exit_message = "errors"
 

--- a/src/markdown_exec/formatters/python.py
+++ b/src/markdown_exec/formatters/python.py
@@ -45,7 +45,7 @@ def _code_block_id(
 
 def _run_python(
     code: str,
-    returncode: int | None = None,
+    exception: str | None = None,
     session: str | None = None,
     id: str | None = None,  # noqa: A002
     **extra: str,
@@ -77,7 +77,7 @@ def _run_python(
                     frame._lines = _code_blocks[frame.filename][frame.lineno - 1]  # type: ignore[attr-defined,operator]
                 else:
                     frame._line = _code_blocks[frame.filename][frame.lineno - 1]  # type: ignore[attr-defined,operator]
-        if returncode not in [None, 0]:
+        if exception is not None and exception in str(error.__class__):
             _buffer_print(buffer, "".join(trace.format()))
         else:
             raise ExecutionError(code_block("python", "".join(trace.format()), **extra)) from error

--- a/src/markdown_exec/formatters/python.py
+++ b/src/markdown_exec/formatters/python.py
@@ -80,7 +80,7 @@ def _run_python(
         if exception is not None and exception in str(error.__class__):
             _buffer_print(buffer, "".join(trace.format()))
         else:
-            raise ExecutionError(code_block("python", "".join(trace.format()), **extra)) from error
+            raise ExecutionError(code_block("python", "".join(trace.format())), exception=str(type(error),  **extra)) from error
     return buffer.getvalue()
 
 

--- a/src/markdown_exec/formatters/python.py
+++ b/src/markdown_exec/formatters/python.py
@@ -45,7 +45,7 @@ def _code_block_id(
 
 def _run_python(
     code: str,
-    returncode: int | None = None,  # noqa: ARG001
+    returncode: int | None = None,
     session: str | None = None,
     id: str | None = None,  # noqa: A002
     **extra: str,
@@ -77,7 +77,10 @@ def _run_python(
                     frame._lines = _code_blocks[frame.filename][frame.lineno - 1]  # type: ignore[attr-defined,operator]
                 else:
                     frame._line = _code_blocks[frame.filename][frame.lineno - 1]  # type: ignore[attr-defined,operator]
-        raise ExecutionError(code_block("python", "".join(trace.format()), **extra)) from error
+        if returncode not in [None, 0]:
+            _buffer_print(buffer, "".join(trace.format()))
+        else:
+            raise ExecutionError(code_block("python", "".join(trace.format()), **extra)) from error
     return buffer.getvalue()
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -229,3 +229,24 @@ def test_future_annotations_do_not_leak_into_user_code(md: Markdown) -> None:
     )
     assert "<code>Int</code>" not in html
     assert re.search(r"class '_code_block_n\d+_\.Int'", html)
+
+
+def test_return_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
+    """Assert return code is used correctly.
+
+    Parameters:
+        md: A Markdown instance (fixture).
+    """
+    html = md.convert(
+        dedent(
+            """
+            ```python exec="yes" returncode="1"
+            print("blah blah blah")
+            raise ValueError
+            ```
+            """,
+        ),
+    )
+    assert "blah blah blah" in html
+    assert "ValueError" in html
+    assert "exited with" not in caplog.text

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -231,7 +231,7 @@ def test_future_annotations_do_not_leak_into_user_code(md: Markdown) -> None:
     assert re.search(r"class '_code_block_n\d+_\.Int'", html)
 
 
-def test_return_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
+def test_exception_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
     """Assert return code is used correctly.
 
     Parameters:
@@ -240,7 +240,7 @@ def test_return_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
     html = md.convert(
         dedent(
             """
-            ```python exec="yes" returncode="1"
+            ```python exec="yes" exception="ValueError"
             print("blah blah blah")
             raise ValueError
             ```
@@ -250,3 +250,17 @@ def test_return_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
     assert "blah blah blah" in html
     assert "ValueError" in html
     assert "exited with" not in caplog.text
+
+    html = md.convert(
+        dedent(
+            """
+            ```python exec="yes" exception="TypeError"
+            print("blah blah blah")
+            raise ValueError
+            ```
+            """,
+        ),
+    )
+    assert "blah blah blah" not in html
+    assert "ValueError" in html
+    assert "ValueError expected TypeErorr" not in caplog.text

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -66,7 +66,7 @@ def test_error_raised(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
     assert "Traceback" in html
     assert "ValueError" in html
     assert "oh no!" in html
-    assert "Execution of python code block exited with errors" in caplog.text
+    assert "Execution of python code block exited with <class 'ValueError'>" in caplog.text
 
 
 def test_can_print_non_string_objects(md: Markdown) -> None:
@@ -263,4 +263,4 @@ def test_exception_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
     )
     assert "blah blah blah" not in html
     assert "ValueError" in html
-    assert "ValueError expected TypeErorr" not in caplog.text
+    assert "<class 'ValueError'> expected TypeError" in caplog.text

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -63,7 +63,7 @@ def test_error_raised(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:
         ),
     )
     assert "error" in html
-    assert "Execution of sh code block exited with unexpected code 2" in caplog.text
+    assert "Execution of sh code block exited with returncode 2 expected 0" in caplog.text
 
 
 def test_return_code(md: Markdown, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
Formats and displays any exceptions when `returncode` is not 0.

This is helpful if you want to demonstrate code that you expect to raise an error. Doubly so when you are running wiht `mkdocs build --strict`

Example rendering in mkdocs-material:
````python
```python exec="on" source="above" returncode="1" result="python"
print("Hello Markdown!")
raise ValueError
```
````
<img width="714" alt="image" src="https://github.com/user-attachments/assets/9e592896-199f-4b0e-bc11-5c35b76d2004" />
