### PR TITLE
feat(formatting) allow empty string in result to imply code format

### DIFF
--- a/src/markdown_exec/__init__.py
+++ b/src/markdown_exec/__init__.py
@@ -72,7 +72,7 @@ def validator(
     id_prefix_value = inputs.pop("idprefix", None)
     html_value = _to_bool(inputs.pop("html", "no"))
     source_value = inputs.pop("source", "")
-    result_value = inputs.pop("result", "")
+    result_value = inputs.pop("result", None)
     returncode_value = int(inputs.pop("returncode", "0"))
     session_value = inputs.pop("session", "")
     update_toc_value = _to_bool(inputs.pop("updatetoc", "yes"))

--- a/src/markdown_exec/formatters/base.py
+++ b/src/markdown_exec/formatters/base.py
@@ -92,7 +92,7 @@ def base_format(
     md: Markdown,
     html: bool = False,
     source: str = "",
-    result: str = "",
+    result: str = None,
     tabs: tuple[str, str] = default_tabs,
     id: str = "",  # noqa: A002
     id_prefix: str | None = None,
@@ -172,7 +172,7 @@ def base_format(
         return Markup(output)
 
     wrapped_output = output
-    if result and source != "console":
+    if result is not None and source != "console":
         wrapped_output = code_block(result, output)
     if source:
         wrapped_output = add_source(

--- a/tests/test_base_formatter.py
+++ b/tests/test_base_formatter.py
@@ -127,3 +127,19 @@ def test_console_width(md: Markdown) -> None:
             width=width,
         )
         assert f"width: {width}" in markup
+
+
+def test_render_as_code_for_empty_string(md: Markdown) -> None:
+    """Assert backticks are added for empty string
+
+    Parameters:
+        md: A Markdown instance (fixture).
+    """
+    markup = base_format(
+        language="python",
+        run=lambda code, **_: code,
+        code="print('hello')",
+        result="",
+        md=md,
+    )
+    assert "<code>" in markup


### PR DESCRIPTION
Sometimes for formatting I found it preferable to have the output wrapped in a code block. In particular for when I had many python print statements. A hacky way to do this is to pass an invalid language name. e.g. `result="code"` but that is not super intuitive. Passing `result=""` was the first thing I tried to get the rendering to work properly so this PR offers that as an option. There is likely a better alternative, but I couldn't immediately think of it.

(I didn't use `result="python"` because that can give confusing syntax highlighting in the print statements. 