### PR TITLE
fix: Fix emoji display in pyodide fence for themes other than Material

### DIFF
--- a/src/markdown_exec/pyodide.css
+++ b/src/markdown_exec/pyodide.css
@@ -48,3 +48,8 @@ html[data-theme="dark"] {
     cursor: pointer;
     text-align: right;
 }
+
+/* For themes other than Material. */
+.pyodide .twemoji svg {
+    width: 1rem;
+}


### PR DESCRIPTION
Issue-83: https://github.com/pawamoy/markdown-exec/issues/83